### PR TITLE
FIXED Warning: forwardRef render functions

### DIFF
--- a/src/components/SnackbarContentWrapper.js
+++ b/src/components/SnackbarContentWrapper.js
@@ -44,7 +44,7 @@ const styles = (theme) => ({
     closeButton: {},
 });
 
-function SnackbarContentWrapper(props, ref) {
+const SnackbarContentWrapper = React.forwardRef((props, ref) => {
     const {classes, className, message, onClose, variant, ...other} = props;
     const Icon = variantIcon[variant];
 
@@ -73,7 +73,7 @@ function SnackbarContentWrapper(props, ref) {
             {...other}
         />
     );
-}
+});
 
 SnackbarContentWrapper.propTypes = {
     classes: PropTypes.object.isRequired,
@@ -83,4 +83,6 @@ SnackbarContentWrapper.propTypes = {
     variant: PropTypes.oneOf(['success', 'warning', 'error', 'info']).isRequired,
 };
 
-export default withStyles(styles, {name: 'MuiDropzoneSnackbar'})(React.forwardRef(SnackbarContentWrapper));
+SnackbarContentWrapper.displayName  = "SnackbarContentWrapper";
+
+export default withStyles(styles, {name: 'MuiDropzoneSnackbar'})(SnackbarContentWrapper);


### PR DESCRIPTION
FIXED Warning: forwardRef render functions do not support propTypes or defaultProps.

## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
  src/components/SnackbarContentWrapper.js
-->

<!--
Link related issues

- Fixes # (issue)
- Fixes # (issue)
-->

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [x] Test A
- [ ] Test B

**Test Configuration**:

- Browser:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
