### PR TITLE
Allow react version later than 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "@mui/icons-material": "^5.0.1",
     "@mui/material": "^5.0.2",
     "@mui/styles": "^5.0.1",
-    "prop-types": "^15.7.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "prop-types": ">15.7.2",
+    "react": ">17.0.2",
+    "react-dom": ">17.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",


### PR DESCRIPTION
Currently, only React version 17 is allowed. This PR allows all React versions which are equal or later than 17